### PR TITLE
Prepare the release of version 0.2.0 of Async RedisCache

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -43,7 +43,7 @@ jobs:
             ${{ hashFiles('Pipfile') }}"
 
       - name: Prepend PATH
-        run: echo '::add-path::${{ env.PYTHONUSERBASE }}/bin'
+        run: echo '${{ env.PYTHONUSERBASE }}/bin' >> $GITHUB_PATH
 
       - name: Install pipenv
         run: pip install pipenv
@@ -57,4 +57,13 @@ jobs:
         run: python -m flake8
 
       - name: Run unittest
-        run: python -m unittest
+        run: |
+          python -m coverage run -m unittest
+          python -m coverage report -m
+
+      # This step will publish the coverage reports coveralls.io and
+      # print a "job" link in the output of the GitHub Action
+      - name: Publish coverage report to coveralls.io
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -m coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 dist/
 *.egg-info
+.coverage

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-exclude tests *
+recursive-include async_rediscache/redis_scripts *.lua

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ pep8-naming = "~=0.11.0"
 
 [packages]
 aioredis = "~=1.3.1"
-fakeredis = "~=1.4.3"
+"fakeredis[lua]" = "~=1.4.4"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ flake8-todo = "~=0.7"
 pep8-naming = "~=0.11.0"
 "coverage[toml]" = "~=5.3"
 coveralls = "~=2.2.0"
+time-machine = "~=1.3.0"
 
 [packages]
 aioredis = "~=1.3.1"

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ flake8-string-format = "~=0.3.0"
 flake8-tidy-imports = "~=4.1.0"
 flake8-todo = "~=0.7"
 pep8-naming = "~=0.11.0"
+coverage = "~=5.3"
+coveralls = "~=2.2.0"
 
 [packages]
 aioredis = "~=1.3.1"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ flake8-string-format = "~=0.3.0"
 flake8-tidy-imports = "~=4.1.0"
 flake8-todo = "~=0.7"
 pep8-naming = "~=0.11.0"
-coverage = "~=5.3"
+"coverage[toml]" = "~=5.3"
 coveralls = "~=2.2.0"
 
 [packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b86f66cdced2f301f18d84910e11d7b28b1851500c59edb3eb229731d408f38b"
+            "sha256": "8ae1ce2107e781d69e3f18bd7b99f96c17f7cbd67de5a9890ff1f35a8c0b95b8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -161,6 +161,75 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.3.0"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+            ],
+            "version": "==2020.12.5"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516",
+                "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259",
+                "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9",
+                "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097",
+                "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0",
+                "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f",
+                "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7",
+                "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c",
+                "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5",
+                "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7",
+                "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729",
+                "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978",
+                "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9",
+                "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f",
+                "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9",
+                "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822",
+                "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418",
+                "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82",
+                "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f",
+                "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d",
+                "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221",
+                "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4",
+                "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21",
+                "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709",
+                "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54",
+                "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d",
+                "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270",
+                "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24",
+                "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751",
+                "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a",
+                "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237",
+                "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7",
+                "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636",
+                "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"
+            ],
+            "index": "pypi",
+            "version": "==5.3"
+        },
+        "coveralls": {
+            "hashes": [
+                "sha256:2301a19500b06649d2ec4f2858f9c69638d7699a4c63027c5d53daba666147cc",
+                "sha256:b990ba1f7bc4288e63340be0433698c1efe8217f78c689d254c2540af3d38617"
+            ],
+            "index": "pypi",
+            "version": "==2.2.0"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
         "flake8": {
             "hashes": [
                 "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
@@ -231,6 +300,14 @@
             "index": "pypi",
             "version": "==0.7"
         },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
@@ -270,12 +347,28 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
+        "requests": {
+            "hashes": [
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
+        },
         "snowballstemmer": {
             "hashes": [
                 "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
                 "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
             ],
             "version": "==2.0.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.2"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8ae1ce2107e781d69e3f18bd7b99f96c17f7cbd67de5a9890ff1f35a8c0b95b8"
+            "sha256": "d103a5e371197f7523e753e7a994d2d020d40290996aa019f461ad7b78492070"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3595ee863a7b5114d86b27655d89a19c188bcc5126f9892752b5a46719a42a22"
+            "sha256": "e1059de8749d46b83e26f80a5e6e47704efd8639fd06e912f813a966de4b75d1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -351,6 +351,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.1"
+        },
         "requests": {
             "hashes": [
                 "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
@@ -359,12 +367,43 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.25.1"
         },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
         "snowballstemmer": {
             "hashes": [
                 "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
                 "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
             ],
             "version": "==2.0.0"
+        },
+        "time-machine": {
+            "hashes": [
+                "sha256:2202cc741b8f4b03dfe83be073bb94d19729255d89a12abf991558dbb74f686b",
+                "sha256:25fa6bf663e152d08f20fdcaedf535613811b2adc1a217fa690141cba08bf611",
+                "sha256:2f20cac8477d6f6f21be5cce1f60c342ebb50f9e88238bfc24a389a74b46433f",
+                "sha256:2f63b7eee63724efafd2c567158e54d6987f4e3d52df3b3699db2408889c09eb",
+                "sha256:356cf634e3a1a2f3b8c27991ab179bae5cc7188b3872c43fc2e5cd425058cda7",
+                "sha256:3cf91cfe761d96827ee63ea5b31a08811e50ea275f589ccceff6dd8dfae3f5fb",
+                "sha256:6f09ea989748f87479f2bf566a9874ebc9111bfc47374dac517e54196f9efcd9",
+                "sha256:83772b58641d76ca307fffd961fc0705a53cf687b1e0e04f8155aa004a4d0b05",
+                "sha256:8694d487e5a382b23de738c78e2bc27e337513128094208f8f69ad8789ca2a7c",
+                "sha256:9505228f98321acbeaa38b4208275b9214e630e05ece9e602847dbc4fd318cc2",
+                "sha256:a8588ae01f0a71deafade8f08788efb53fa5840dd3c0ae9c95a4a8cc4f8d074d",
+                "sha256:bce9e572cf980c2d03bd5871c66969ae3e15ca91f27949dcf1f12b6545d7ffb3",
+                "sha256:bddab1bb4179fd4ae5d9ad3fcbfd5b04903c96df7717606da3004195d6902c9c",
+                "sha256:c534ae6db31c8d69975c1b3a3ea194d2873da7addba0ac69fda7e37ef89f6608",
+                "sha256:c5d0ddb900c058764b4852ca455b2afa7f96d67cc3d2a8e5a69b028578533001",
+                "sha256:e1a467012c5db77e220af84a26d4cc482a700bd895641ebc1aeddf049ae1a35a",
+                "sha256:e397ce0d1b06cf63445ecf0cbbd5b4a31b87f15a919d53481868026d1a24bddc"
+            ],
+            "index": "pypi",
+            "version": "==1.3.0"
         },
         "toml": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d103a5e371197f7523e753e7a994d2d020d40290996aa019f461ad7b78492070"
+            "sha256": "3595ee863a7b5114d86b27655d89a19c188bcc5126f9892752b5a46719a42a22"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -177,6 +177,9 @@
             "version": "==4.0.0"
         },
         "coverage": {
+            "extras": [
+                "toml"
+            ],
             "hashes": [
                 "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516",
                 "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259",
@@ -214,6 +217,7 @@
                 "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"
             ],
             "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==5.3"
         },
         "coveralls": {
@@ -361,6 +365,13 @@
                 "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
             ],
             "version": "==2.0.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "version": "==0.10.2"
         },
         "urllib3": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b86cd21aa4d9d28434f959ed9ab43063f966054cfd49a26a19b9b7cf171305e"
+            "sha256": "b86f66cdced2f301f18d84910e11d7b28b1851500c59edb3eb229731d408f38b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -33,12 +33,16 @@
             "version": "==3.0.1"
         },
         "fakeredis": {
+            "extras": [
+                "lua"
+            ],
             "hashes": [
-                "sha256:7ea0866ba5edb40fe2e9b1722535df0c7e6b91d518aa5f50d96c2fff3ea7f4c2",
-                "sha256:aad8836ffe0319ffbba66dcf872ac6e7e32d1f19790e31296ba58445efb0a5c7"
+                "sha256:01cb47d2286825a171fb49c0e445b1fa9307087e07cbb3d027ea10dbff108b6a",
+                "sha256:2c6041cf0225889bc403f3949838b2c53470a95a9e2d4272422937786f5f8f73"
             ],
             "index": "pypi",
-            "version": "==1.4.3"
+            "markers": "python_version >= '3.5'",
+            "version": "==1.4.5"
         },
         "hiredis": {
             "hashes": [
@@ -92,6 +96,38 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.0"
         },
+        "lupa": {
+            "hashes": [
+                "sha256:09d6c45eb3b9407588c5a168e3371b629e75c5822050e9feff393601709bd0d7",
+                "sha256:162f6793b2ad40d25710b9998bce2eeb3938efbb4dbad49fb8c5082d214237b3",
+                "sha256:2551ae82ea0f90383fb153ecd29a1a166e2552e10b7a712ff047cad88062ad37",
+                "sha256:42285855c022b36ed3f0c5d19d0ef27b1648e0683838cddaf9191acad4d6616c",
+                "sha256:42fcd8f7b33b84abce90c57aaeb80d9a2ba3c3fdb4cde2fac1c8f9e4eb00d581",
+                "sha256:49afbeaf90c758512d3c0dea48ac0ecfa460974690cf1af58b95845e6b607c4b",
+                "sha256:4badf4180f8fd28e032e8716422b7a0117879569e694b5e2e803a7e39fa85213",
+                "sha256:517b96b23b4ce19feb54ee93d8c3b94f601a3d46cd1d570ecc5137fc7b9cb68c",
+                "sha256:5e08a97a4ae46592f1fd04f2f97d9fdeb6a34dbcdc0a049e1ca5929e6902c558",
+                "sha256:632e7a101c288e05b823c2bae71ac69e0253e7f4120bc39b5dc1fcaf5daba0fb",
+                "sha256:6d65bdc251cd12b85487a1790ca1b282288be84555fe11fbe8b4357ae64708f5",
+                "sha256:7619fbd85d9ece1d48fb72bb7389e98d878621d2da0b7622c99066671f294b65",
+                "sha256:7df1f565b92f124e45093dde8d262489a67f40eddd7a65035e6bc3b982be234f",
+                "sha256:8434fdda16d101c458570d21baf9cd064304b515ed4ef9569949222ba04c3e37",
+                "sha256:9823322e60b0d9695754e28f5a17323d111d6951933e958cfe72df9523a39e94",
+                "sha256:9ee2aa3e1e852a2917c5869e8ab69d725407a218d14c4c0c98f4b04b3b2a73a7",
+                "sha256:a3e11d806ca02cf72e490ec1974f8b96a14a1091895c9dccebe0b8d52dd82e8e",
+                "sha256:a690b0bafb7e50dd8ba14a06065059b11f5c8e5961564d5d45de2d9b4a9972b1",
+                "sha256:a7d7761b007fbf8b524291ac42bccc32b072102e7f7e547783a5a5ded66a0c39",
+                "sha256:abb357c35ad1c1b78b140c8cf1fd678bcaa04bab275c6d55e47a07717138e551",
+                "sha256:ac7585125af7d7214e1f9dbdda965d7455c5065f71be20374c7900e01c74c05f",
+                "sha256:acaecd88ce6b708fbaf20b76b4d35ecb2817159f8a939b0a73d2aa840dfef850",
+                "sha256:ba879849832b87c18dbc471bffc62ff3393b2034a3b103348d620646575f448a",
+                "sha256:c57cda6ba3dc55ddd8b6c566c4f315d6152307aee23f212aa06c5e653cde4f13",
+                "sha256:d3cf15d0c1126373535452bdeb71b016fe970d7e5ee2bc0381df7bd35f99c820",
+                "sha256:d497f4727060a1daf8603e86cb731f587c38ab9a3451cd3c9c70f27859cbd3bd",
+                "sha256:fe1db400b471a0854fe364b63d7836973ee0d897a76628340d1721b6b4b89ddc"
+            ],
+            "version": "==1.9"
+        },
         "redis": {
             "hashes": [
                 "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2",
@@ -110,36 +146,36 @@
         },
         "sortedcontainers": {
             "hashes": [
-                "sha256:4e73a757831fc3ca4de2859c422564239a31d8213d09a2a666e375807034d2ba",
-                "sha256:c633ebde8580f241f274c1f8994a665c0e54a17724fecd0cae2f079e09c36d3f"
+                "sha256:37257a32add0a3ee490bb170b599e93095eed89a55da91fa9f48753ea12fd73f",
+                "sha256:59cc937650cf60d677c16775597c89a960658a09cf7c1a668f86e1e4464b10a1"
             ],
-            "version": "==2.2.2"
+            "version": "==2.3.0"
         }
     },
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
-                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.2.0"
+            "version": "==20.3.0"
         },
         "flake8": {
             "hashes": [
-                "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c",
-                "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"
+                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
+                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
             ],
             "index": "pypi",
-            "version": "==3.8.3"
+            "version": "==3.8.4"
         },
         "flake8-annotations": {
             "hashes": [
-                "sha256:09fe1aa3f40cb8fef632a0ab3614050a7584bb884b6134e70cf1fc9eeee642fa",
-                "sha256:5bda552f074fd6e34276c7761756fa07d824ffac91ce9c0a8555eb2bc5b92d7a"
+                "sha256:0bcebb0792f1f96d617ded674dca7bf64181870bfe5dace353a1483551f8e5f1",
+                "sha256:bebd11a850f6987a943ce8cdff4159767e0f5f89b3c88aca64680c2175ee02df"
             ],
             "index": "pypi",
-            "version": "==2.4.0"
+            "version": "==2.4.1"
         },
         "flake8-bugbear": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Coverage Status](https://coveralls.io/repos/github/python-discord/async-rediscache/badge.svg?branch=master)](https://coveralls.io/github/python-discord/async-rediscache?branch=master)
+![Lint & Test](https://github.com/python-discord/async-rediscache/workflows/Lint%20&%20Test/badge.svg)
+![Release to PyPI](https://github.com/python-discord/async-rediscache/workflows/Release%20to%20PyPI/badge.svg)
+
 # Asynchronous Redis Cache
 This package offers several data types to ease working with a Redis cache in an asynchronous workflow. The package is currently in development and it's not recommended to start using it in production at this point.
 

--- a/async_rediscache/redis_scripts/rediscache_increment.lua
+++ b/async_rediscache/redis_scripts/rediscache_increment.lua
@@ -1,0 +1,35 @@
+local value = redis.call('HGET', KEYS[1], KEYS[2]);
+if not value then value = "i|0" end
+
+local get_prefix = function (redis_value)
+    local prefix_end = redis_value:find("|")
+    return prefix_end, redis_value:sub(1, prefix_end-1)
+end
+
+local value_prefix_end, value_prefix = get_prefix(value)
+if not value_prefix_end then
+    return string.format("ValueError|received malformed value from keys %s %s: `%s`", KEYS[1], KEYS[1], value)
+end
+
+local increment = ARGV[1]
+local incr_prefix_end, incr_prefix = get_prefix(increment)
+if not incr_prefix_end then
+    return string.format("ValueError|received malformed increment value: `%s`", increment)
+end
+
+local valid_prefixes = "if"
+local valid_values = valid_prefixes:match(value_prefix) and valid_prefixes:match(incr_prefix)
+if not valid_values then
+    return string.format("TypeError|cannot increment value `%s` with `%s`.", value, ARGV[1])
+end
+
+local new_value = value:sub(value_prefix_end+1) + increment:sub(incr_prefix_end+1)
+local result
+if incr_prefix..value_prefix == "ii" then
+    result = string.format("i|%d", new_value)
+else
+    result = string.format("f|%s", tostring(new_value))
+end
+
+redis.call("HSET", KEYS[1], KEYS[2], result)
+return result

--- a/async_rediscache/redis_scripts/rediscache_pop.lua
+++ b/async_rediscache/redis_scripts/rediscache_pop.lua
@@ -1,0 +1,3 @@
+local popped_value = redis.call('HGET', KEYS[1], KEYS[2])
+redis.call('HDEL', KEYS[1], KEYS[2])
+return popped_value

--- a/async_rediscache/redis_scripts/redisqueue_reschedule_all_client_tasks.lua
+++ b/async_rediscache/redis_scripts/redisqueue_reschedule_all_client_tasks.lua
@@ -1,6 +1,14 @@
 local queue_size = redis.call("LLEN", KEYS[2])
 local client_tasks = redis.call("LRANGE", KEYS[2], 0, queue_size)
 
+-- For Lua version compatibility, try picking the right version of unpack
+local unpack_function
+if unpack == nil then
+  unpack_function = table.unpack
+else
+  unpack_function = unpack
+end
+
 if queue_size > 0 then
   redis.call("LPUSH", KEYS[1], unpack(client_tasks))
 end

--- a/async_rediscache/redis_scripts/redisqueue_reschedule_all_client_tasks.lua
+++ b/async_rediscache/redis_scripts/redisqueue_reschedule_all_client_tasks.lua
@@ -1,0 +1,9 @@
+local queue_size = redis.call("LLEN", KEYS[2])
+local client_tasks = redis.call("LRANGE", KEYS[2], 0, queue_size)
+
+if queue_size > 0 then
+  redis.call("LPUSH", KEYS[1], unpack(client_tasks))
+end
+
+redis.call("DEL", KEYS[2])
+return queue_size

--- a/async_rediscache/redis_scripts/redisqueue_reschedule_all_client_tasks.lua
+++ b/async_rediscache/redis_scripts/redisqueue_reschedule_all_client_tasks.lua
@@ -10,7 +10,7 @@ else
 end
 
 if queue_size > 0 then
-  redis.call("LPUSH", KEYS[1], unpack(client_tasks))
+  redis.call("RPUSH", KEYS[1], unpack_function(client_tasks))
 end
 
 redis.call("DEL", KEYS[2])

--- a/async_rediscache/redis_scripts/redisqueue_reschedule_task.lua
+++ b/async_rediscache/redis_scripts/redisqueue_reschedule_task.lua
@@ -1,0 +1,6 @@
+local number_rescheduled = redis.call("LREM", KEYS[2], 1, ARGV[1])
+if number_rescheduled == 0 then
+    return redis.error_reply("Task not found in pending tasks queue.")
+end
+
+redis.call("LPUSH", KEYS[1], ARGV[1])

--- a/async_rediscache/types/base.py
+++ b/async_rediscache/types/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import functools
 import importlib.resources
 import logging
@@ -52,6 +53,105 @@ _ERROR_PREFIXES = (
 
 class NoNamespaceError(RuntimeError):
     """Raised when a RedisCache instance has no namespace."""
+
+
+class NamespaceLock(asyncio.Lock):
+    """
+    An asyncio.Lock subclass that is aware of the namespace that it's locking.
+
+    This class is DEPRECATED and will be removed in version 1.0.0. See the
+    docstring of the `namespace_lock` decorator for more information.
+    """
+
+    def __init__(self, namespace: str, *, warn: bool = True) -> None:
+        if warn:
+            warnings.warn(
+                "The use of `NamespaceLock` is deprecated. It will be removed "
+                "entirely in version 1.0.0.",
+                DeprecationWarning
+            )
+
+        super().__init__()
+        self._namespace = namespace
+
+    def __repr__(self) -> str:
+        """Create an insightful representation for this NamespaceLock object."""
+        status = "locked" if self.locked() else "unlocked"
+        cls = self.__class__.__name__
+        return f"<{cls} namespace={self._namespace!r} [{status}]>"
+
+
+def namespace_lock(method: Callable, *, warn: bool = True) -> Callable:
+    """
+    Atomify the decorated method from a Redis perspective.
+
+    Namespace locks are DEPRECATED. The issue with namespace locks is that it is
+    very easy to implement something that will deadlock. They were used to wrap
+    compound methods that had to issue multiple Redis Commands to do their work.
+
+    The downside is that if one method uses another method internally, it needs
+    to make sure that the other method does not try to acquire the lock, as the
+    calling method already has it. If not, a deadlock will occur where the
+    method called internally is waiting for a lock that's acquired by its
+    caller, while the caller will only release the lock after the work is done.
+
+    Another downside is that in a multiple client setup, such a lock is specific
+    to a single client. This means that while atomicity is pseudo-guaranteed
+    within a client, race conditions between clients still occur.
+
+    To solve the issue, async-rediscache has switched to an approach using Redis
+    scripting that brings the atomicity of the entire operation to the side of
+    Redis again.
+
+    This decorator will be removed in version 1.0.0, but it's kept around with
+    a deprecation warning until it's removed.
+    """
+    if warn:
+        warnings.warn(
+            "The `namespace_lock` decorator is deprecated. It will be removed "
+            "completely in version 1.0.0.",
+            DeprecationWarning
+        )
+
+    @functools.wraps(method)
+    async def wrapper(self, *args, acquire_lock: bool = True, **kwargs) -> Any:  # noqa: ANN001
+        """
+        Wrap the method in a function that automatically acquires a NamespaceLock.
+
+        If `acquire_lock` is `False`, acquiring the lock will be skipped. This
+        allows a compound method to call other methods without triggering a
+        deadlock situation.
+        """
+        coroutine_object = method(self, *args, **kwargs)
+        if acquire_lock:
+            # Get fully qualified namespace to fetch the correct lock
+            namespace = self.namespace
+
+            # Check if we already have a lock for namespace; if not, create it.
+            if namespace not in self._namespace_locks:
+                log.debug(f"Creating NamespaceLock for {namespace=}.")
+                self._namespace_locks[namespace] = NamespaceLock(
+                    namespace=namespace, warn=warn
+                )
+
+            # Get the lock for this namespace
+            lock = self._namespace_locks[namespace]
+
+            # Acquire lock
+            log.debug(f"Trying to acquire {lock} for {method.__qualname__}")
+            async with lock:
+                log.debug(f"Acquired {lock} for {method.__qualname__}")
+                result = await coroutine_object
+            log.debug(f"Released {lock} for {method.__qualname__}")
+        else:
+            result = await coroutine_object
+
+        return result
+
+    return wrapper
+
+
+namespace_lock_no_warn = functools.partial(namespace_lock, warn=False)
 
 
 class RedisObject:
@@ -267,101 +367,39 @@ class RedisObject:
 
         return wrapper
 
-
-class NamespaceLock(asyncio.Lock):
-    """
-    An asyncio.Lock subclass that is aware of the namespace that it's locking.
-
-    This class is DEPRECATED and will be removed in version 1.0.0. See the
-    docstring of the `namespace_lock` decorator for more information.
-    """
-
-    def __init__(self, namespace: str, *, warn: bool = True) -> None:
-        if warn:
-            warnings.warn(
-                "The use of `NamespaceLock` is deprecated. It will be removed "
-                "entirely in version 1.0.0.",
-                DeprecationWarning
-            )
-
-        super().__init__()
-        self._namespace = namespace
-
-    def __repr__(self) -> str:
-        """Create an insightful representation for this NamespaceLock object."""
-        status = "locked" if self.locked() else "unlocked"
-        cls = self.__class__.__name__
-        return f"<{cls} namespace={self._namespace!r} [{status}]>"
-
-
-def namespace_lock(method: Callable, *, warn: bool = True) -> Callable:
-    """
-    Atomify the decorated method from a Redis perspective.
-
-    Namespace locks are DEPRECATED. The issue with namespace locks is that it is
-    very easy to implement something that will deadlock. They were used to wrap
-    compound methods that had to issue multiple Redis Commands to do their work.
-
-    The downside is that if one method uses another method internally, it needs
-    to make sure that the other method does not try to acquire the lock, as the
-    calling method already has it. If not, a deadlock will occur where the
-    method called internally is waiting for a lock that's acquired by its
-    caller, while the caller will only release the lock after the work is done.
-
-    Another downside is that in a multiple client setup, such a lock is specific
-    to a single client. This means that while atomicity is pseudo-guaranteed
-    within a client, race conditions between clients still occur.
-
-    To solve the issue, async-rediscache has switched to an approach using Redis
-    scripting that brings the atomicity of the entire operation to the side of
-    Redis again.
-
-    This decorator will be removed in version 1.0.0, but it's kept around with
-    a deprecation warning until it's removed.
-    """
-    if warn:
-        warnings.warn(
-            "The `namespace_lock` decorator is deprecated. It will be removed "
-            "completely in version 1.0.0.",
-            DeprecationWarning
-        )
-
-    @functools.wraps(method)
-    async def wrapper(self, *args, acquire_lock: bool = True, **kwargs) -> Any:  # noqa: ANN001
+    @namespace_lock_no_warn
+    async def set_expiry(self, seconds: float) -> bool:
         """
-        Wrap the method in a function that automatically acquires a NamespaceLock.
+        Set a time-to-live on the entire RedisCache namespace.
 
-        If `acquire_lock` is `False`, acquiring the lock will be skipped. This
-        allows a compound method to call other methods without triggering a
-        deadlock situation.
+        This method accepts a precision down to 1 ms. If more decimal
+        places are provided, the duration is truncated. Passing a
+        negative expire will result in the namespace being deleted
+        immediately.
+
+        Note: Setting an expiry on a key within the namespace is not
+        supported by Redis. It's the entire namespace or nothing.
         """
-        coroutine_object = method(self, *args, **kwargs)
-        if acquire_lock:
-            # Get fully qualified namespace to fetch the correct lock
-            namespace = self.namespace
+        with await self._get_pool_connection() as connection:
+            result = await connection.pexpire(self.namespace, int(1000*seconds))
 
-            # Check if we already have a lock for namespace; if not, create it.
-            if namespace not in self._namespace_locks:
-                log.debug(f"Creating NamespaceLock for {namespace=}.")
-                self._namespace_locks[namespace] = NamespaceLock(
-                    namespace=namespace, warn=warn
-                )
+        return bool(result)
 
-            # Get the lock for this namespace
-            lock = self._namespace_locks[namespace]
+    @namespace_lock_no_warn
+    async def set_expiry_at(self, timestamp: Union[datetime.datetime, float]) -> bool:
+        """
+        Set a specific timestamp for the entire RedisCache to expire.
 
-            # Acquire lock
-            log.debug(f"Trying to acquire {lock} for {method.__qualname__}")
-            async with lock:
-                log.debug(f"Acquired {lock} for {method.__qualname__}")
-                result = await coroutine_object
-            log.debug(f"Released {lock} for {method.__qualname__}")
-        else:
-            result = await coroutine_object
+        This method accepts either a `datetime.datetime` or seconds since
+        the Unix Epoch with a maximum precision of four decimal places (ms).
 
-        return result
+        Note: Setting an expiry on a key within the namespace is not
+        supported by Redis. It's the entire namespace or nothing.
+        """
+        if isinstance(timestamp, datetime.datetime):
+            timestamp = timestamp.timestamp()
 
-    return wrapper
+        with await self._get_pool_connection() as connection:
+            result = await connection.pexpireat(self.namespace, int(1000*timestamp))
 
-
-namespace_lock_no_warn = functools.partial(namespace_lock, warn=False)
+        return bool(result)

--- a/async_rediscache/types/cache.py
+++ b/async_rediscache/types/cache.py
@@ -90,13 +90,7 @@ class RedisCache(RedisObject):
         with await self._get_pool_connection() as connection:
             value = await connection.hget(self.namespace, key)
 
-        if value is None:
-            log.debug(f"Value not found, returning default value {default}")
-            return default
-        else:
-            value = self._value_from_typestring(value)
-            log.debug(f"Value found, returning value {value}")
-            return value
+        return self._maybe_value_from_typestring(value, default)
 
     @namespace_lock_no_warn
     async def delete(self, key: RedisKeyType) -> None:
@@ -184,7 +178,7 @@ class RedisCache(RedisObject):
         )
         await self.delete(key, acquire_lock=False)
 
-        return value
+        return self._maybe_value_from_typestring(value, default)
 
     @namespace_lock_no_warn
     async def update(self, items: Dict[RedisKeyType, RedisValueType]) -> None:

--- a/async_rediscache/types/cache.py
+++ b/async_rediscache/types/cache.py
@@ -220,11 +220,10 @@ class RedisCache(RedisObject):
 
         return self._maybe_value_from_typestring(value)
 
-    @namespace_lock_no_warn
     async def decrement(self, key: RedisKeyType, amount: Optional[float] = 1) -> float:
         """
         Decrement the value by `amount`.
 
         Basically just does the opposite of .increment.
         """
-        return await self.increment(key, -amount, acquire_lock=False)
+        return await self.increment(key, -amount)

--- a/async_rediscache/types/queue.py
+++ b/async_rediscache/types/queue.py
@@ -43,7 +43,7 @@ class RedisQueue(RedisObject):
         value_string = self._value_to_typestring(value)
         log.debug(f"putting {value_string!r} on RedisQueue `{self.namespace}`")
         with await self._get_pool_connection() as connection:
-            await connection.rpush(self.namespace, value_string)
+            await connection.lpush(self.namespace, value_string)
 
     # This method is provided to provide a compatible interface with Queue.SimpleQueue
     put_nowait = functools.partialmethod(put)
@@ -68,7 +68,7 @@ class RedisQueue(RedisObject):
 
         with await self._get_pool_connection() as connection:
             if wait:
-                value = await connection.blpop(self.namespace, timeout=timeout)
+                value = await connection.brpop(self.namespace, timeout=timeout)
 
                 # If we can get an item from the queue before the timeout runs
                 # out, we get a list back, in the form `[namespace, value]`. If
@@ -78,7 +78,7 @@ class RedisQueue(RedisObject):
                 if value:
                     _, value = value
             else:
-                value = await connection.lpop(self.namespace)
+                value = await connection.rpop(self.namespace)
 
         if value is not None:
             value = self._value_from_typestring(value)

--- a/async_rediscache/types/queue.py
+++ b/async_rediscache/types/queue.py
@@ -2,7 +2,7 @@ import functools
 import logging
 from typing import Optional
 
-from .base import RedisObject, RedisValueType, namespace_lock
+from .base import RedisObject, RedisValueType, namespace_lock_no_warn
 
 __all__ = [
     "RedisQueue",
@@ -27,7 +27,7 @@ class RedisQueue(RedisObject):
     namespace as the `namespace` keyword argument to constructor.
     """
 
-    @namespace_lock
+    @namespace_lock_no_warn
     async def put(self, value: RedisValueType) -> None:
         """
         Remove and return a value from the queue.
@@ -48,7 +48,7 @@ class RedisQueue(RedisObject):
     # This method is provided to provide a compatible interface with Queue.SimpleQueue
     put_nowait = functools.partialmethod(put)
 
-    @namespace_lock
+    @namespace_lock_no_warn
     async def get(self, wait: bool = True, timeout: int = 0) -> Optional[RedisValueType]:
         """
         Remove and return a value from the queue.
@@ -89,7 +89,7 @@ class RedisQueue(RedisObject):
     # This method is provided to provide a compatible interface with Queue.SimpleQueue
     get_nowait = functools.partialmethod(get, wait=False)
 
-    @namespace_lock
+    @namespace_lock_no_warn
     async def qsize(self) -> int:
         """
         Return the (approximate) size of the RedisQueue.
@@ -101,7 +101,7 @@ class RedisQueue(RedisObject):
         with await self._get_pool_connection() as connection:
             return await connection.llen(self.namespace)
 
-    @namespace_lock
+    @namespace_lock_no_warn
     async def empty(self) -> bool:
         """
         Return `True` if the RedisQueue is empty.

--- a/async_rediscache/types/queue.py
+++ b/async_rediscache/types/queue.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import functools
 import logging
+import typing
 import weakref
 from typing import Optional
-
-import typing
 
 import aioredis
 
 from .base import RedisObject, RedisValueType, namespace_lock_no_warn
+
 
 __all__ = [
     "RedisQueue",

--- a/async_rediscache/types/queue.py
+++ b/async_rediscache/types/queue.py
@@ -1,14 +1,33 @@
+from __future__ import annotations
+
 import functools
 import logging
+import weakref
 from typing import Optional
+
+import typing
+
+import aioredis
 
 from .base import RedisObject, RedisValueType, namespace_lock_no_warn
 
 __all__ = [
     "RedisQueue",
+    "RedisTaskQueue",
+    "RedisTask",
+    "TaskAlreadyDone",
+    "TaskNotPending",
 ]
 
 log = logging.getLogger(__name__)
+
+
+class TaskAlreadyDone(RuntimeError):
+    """Raised when finalized is called on a task that is already done."""
+
+
+class TaskNotPending(RuntimeError):
+    """Raised when finalizing a task that is not found in the 'pending' queue."""
 
 
 class RedisQueue(RedisObject):
@@ -109,3 +128,166 @@ class RedisQueue(RedisObject):
         The caveat that applies to the `qsize` method also applies here.
         """
         return await self.qsize(acquire_lock=False) == 0
+
+    async def iter_tasks(
+            self, wait: bool = True, timeout: int = 0
+    ) -> typing.AsyncGenerator[typing.Union[RedisValueType, RedisTask], None, None]:
+        """Yield all items the queue, optionally waiting for new tasks."""
+        while True:
+            value = await self.get(wait, timeout)
+            if value is None:
+                return
+
+            yield value
+
+    def __aiter__(
+            self
+    ) -> typing.AsyncGenerator[typing.Union[RedisValueType, RedisTask], None, None]:
+        """Yield all items in the queue until it's emptied."""
+        return self.iter_tasks(wait=False)
+
+
+class RedisTaskQueue(RedisQueue):
+    """A Queue class with task tracking features to prevent data loss."""
+
+    def __init__(self, *args, client_identifier: typing.Optional[str] = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.client_identifier = client_identifier
+
+    @property
+    def namespace_pending(self) -> str:
+        """Get the name of the queue where pending tasks are stored."""
+        client_id = f"{self.client_identifier}_" if self.client_identifier is not None else ""
+        return f"{self.namespace}${client_id}pending"
+
+    async def get(self, wait: bool = True, timeout: int = 0) -> Optional[RedisTask]:
+        """
+        Get an item from the queue wrapped in a Task instance.
+
+        When you get an item from the queue, it will not be directly removed
+        from Redis. Instead, it will be moved to an in-progress list to prevent
+        data loss in case the worker is interrupted for its job is completed.
+
+        You should mark a `Task` as done by calling its `finalize` method in the
+        worker once it has completed its work to prevent items from staying
+        alive indefinitely. See the `Task` class for more information.
+        """
+        log.debug(
+            f"getting value from RedisTaskQueue `{self.namespace}` "
+            f"(wait={wait!r}, timeout={timeout!r})"
+        )
+
+        namespaces = {"sourcekey": self.namespace, "destkey": self.namespace_pending}
+        with await self._get_pool_connection() as connection:
+            if wait:
+                value = await connection.brpoplpush(**namespaces, timeout=timeout)
+            else:
+                value = await connection.rpoplpush(**namespaces)
+
+        if value is not None:
+            value = self._value_from_typestring(value)
+            value = RedisTask(value, owner=self)
+
+        log.debug(f"got value `{value!r}` from RedisTaskQueue `{self.namespace}`")
+        return value
+
+    async def task_done(self, task: RedisTask) -> None:
+        """Mark a task as done by removing it from the pending tasks queue."""
+        typestring = self._value_to_typestring(task.value)
+        with await self._get_pool_connection() as connection:
+            removed = await connection.lrem(self.namespace_pending, 1, typestring)
+
+        if not removed:
+            raise TaskNotPending(f"task {task.value!r} was not found in the pending tasks queue.")
+
+        task.done = True
+
+    async def reschedule_pending_task(self, task: typing.Union[RedisValueType. RedisTask]) -> None:
+        """
+        Move a `task` from the pending tasks queue back to the main queue.
+
+        This is a DANGEROUS operation: Rescheduling a task that is currently
+        still being processed by a worker leads to an inconsistent state: The
+        task is still being processed, but it's also queued to be processed
+        again. It will also trigger a `RuntimeError` when the worker attempts
+        to mark the task as done as the task will not be found in the pending
+        tasks queue.
+        """
+        if isinstance(task, RedisTask):
+            task = task.value
+
+        reschedule_script = await self._load_script("redisqueue_reschedule_task.lua")
+
+        with await self._get_pool_connection() as connection:
+            try:
+                await connection.evalsha(
+                    reschedule_script,
+                    keys=[self.namespace, self.namespace_pending],
+                    args=[self._value_to_typestring(task)],
+                )
+            except aioredis.ReplyError:
+                raise TaskNotPending(
+                    f"task `{task!r}` not found in pending tasks queue `{self.namespace_pending}`"
+                ) from None
+
+    async def reschedule_all_pending_client_tasks(self) -> int:
+        """
+        Reschedule all pending tasks of this client.
+
+        This is a DANGEROUS operation that could lead to an inconsistent state
+        in the queue. See `RedisTaskQueue.reschedule_pending_task` for more
+        information.
+        """
+        reschedule_script = await self._load_script("redisqueue_reschedule_all_client_tasks.lua")
+        with await self._get_pool_connection() as connection:
+            rescheduled_tasks = await connection.evalsha(
+                reschedule_script,
+                keys=[self.namespace, self.namespace_pending],
+            )
+
+        return int(rescheduled_tasks)
+
+
+class RedisTask:
+    """
+    A class that represents a task popped from a RedisQueue.
+
+    A task has a weak reference to its owner queue, which means you can mark a
+    task as done as long as the owner queue is still alive.
+    """
+
+    def __init__(self, value: RedisValueType, owner: RedisQueue) -> None:
+        self._value = value
+        self.owner_reference = weakref.ref(owner)
+        self.done = False
+
+    def __repr__(self) -> str:
+        """Return the official representation of the task."""
+        cls = self.__class__.__name__
+        status = "done" if self.done else "pending"
+        return f"<{cls} task_data={self._value!r} [{status}]>"
+
+    @property
+    def value(self) -> RedisValueType:
+        """Return the task value."""
+        return self._value
+
+    @property
+    def owner(self) -> RedisTaskQueue:
+        """Get the owner RedisTaskQueue from the weak reference."""
+        queue = self.owner_reference()
+        if not queue:
+            raise RuntimeError("can't finalize task as the queue instance no longer exists")
+
+        return queue
+
+    async def finalize(self) -> None:
+        """Mark the task as done and remove it from the pending tasks queue."""
+        if self.done:
+            raise TaskAlreadyDone("task was already marked as done")
+
+        await self.owner.task_done(task=self)
+
+    async def reschedule(self) -> None:
+        """Reschedule this task in the main queue."""
+        await self.owner.reschedule_pending_task(self)

--- a/async_rediscache/types/queue.py
+++ b/async_rediscache/types/queue.py
@@ -160,6 +160,7 @@ class RedisTaskQueue(RedisQueue):
         client_id = f"{self.client_identifier}_" if self.client_identifier is not None else ""
         return f"{self.namespace}${client_id}pending"
 
+    @namespace_lock_no_warn
     async def get(self, wait: bool = True, timeout: int = 0) -> Optional[RedisTask]:
         """
         Get an item from the queue wrapped in a Task instance.
@@ -191,6 +192,7 @@ class RedisTaskQueue(RedisQueue):
         log.debug(f"got value `{value!r}` from RedisTaskQueue `{self.namespace}`")
         return value
 
+    @namespace_lock_no_warn
     async def task_done(self, task: RedisTask) -> None:
         """Mark a task as done by removing it from the pending tasks queue."""
         typestring = self._value_to_typestring(task.value)
@@ -202,6 +204,7 @@ class RedisTaskQueue(RedisQueue):
 
         task.done = True
 
+    @namespace_lock_no_warn
     async def reschedule_pending_task(self, task: typing.Union[RedisValueType. RedisTask]) -> None:
         """
         Move a `task` from the pending tasks queue back to the main queue.
@@ -230,6 +233,7 @@ class RedisTaskQueue(RedisQueue):
                     f"task `{task!r}` not found in pending tasks queue `{self.namespace_pending}`"
                 ) from None
 
+    @namespace_lock_no_warn
     async def reschedule_all_pending_client_tasks(self) -> int:
         """
         Reschedule all pending tasks of this client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.coverage.run]
+branch = true
+source = [
+  "async_rediscache",
+  "tests",
+]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="async-rediscache",
-    version="0.1.4",
+    version="0.2.0",
     description="An easy to use asynchronous Redis cache",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Framework :: AsyncIO",
         "Topic :: Database",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     python_requires='~=3.7',
     extras_require={
-        "fakeredis": ["fakeredis>=1.3.1"],
+        "fakeredis": ["fakeredis[lua]>=1.4.4"],
     },
     include_package_data=True,
     zip_safe=False

--- a/tests/types/helpers.py
+++ b/tests/types/helpers.py
@@ -14,5 +14,9 @@ class BaseRedisObjectTests(unittest.IsolatedAsyncioTestCase):
         self.mock_session.get_current_session.return_value = self.mock_session
         self.mock_session.pool = await fakeredis.aioredis.create_redis_pool()
 
+        # Flush everything from the database to prevent carry-overs between tests
+        with await self.mock_session.pool as connection:
+            await connection.flushall()
+
     async def asyncTearDown(self):
         self.patcher.stop()

--- a/tests/types/test_queue.py
+++ b/tests/types/test_queue.py
@@ -9,7 +9,7 @@ class RedisQueueTests(BaseRedisObjectTests):
 
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.queue = types.RedisQueue(namespace="test_cache")
+        self.queue = types.RedisQueue(namespace="test_queue")
 
     async def test_put_get_no_wait(self):
         """Test the .put and .get method without waiting, open connections."""
@@ -96,3 +96,197 @@ class RedisQueueTests(BaseRedisObjectTests):
         await self.queue.get()
         self.assertEqual(await self.queue.qsize(), 0)
         self.assertTrue(await self.queue.empty())
+
+
+class RedisTaskQueueTests(BaseRedisObjectTests):
+    """Tests for teh RedisTaskQueue class."""
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.queue = types.RedisTaskQueue(namespace="task_queue")
+
+    async def test_get_also_pushes_task_to_pending(self):
+        """Test if the `.get` also pushes the task to the pending tasks queue."""
+        test_value = "Python Discord"
+        await self.queue.put(test_value)
+        task = await self.queue.get()
+
+        with await self.mock_session.pool as connection:
+            queue_length = await connection.llen(self.queue.namespace)
+            pending_length = await connection.llen(self.queue.namespace_pending)
+
+        self.assertEqual(task.value, test_value)
+        self.assertEqual(queue_length, 0)
+        self.assertEqual(pending_length, 1)
+
+    async def test_task_finalize_correctly_finalizes_task(self):
+        """`task.finalize` should remove the task from the pending queue and marks it as done.`"""
+        test_value = "Python Discord"
+        await self.queue.put(test_value)
+        self.assertEqual(await self.queue.qsize(), 1)
+
+        task = await self.queue.get()
+        self.assertEqual(await self.queue.qsize(), 0)
+        self.assertEqual(task.value, test_value)
+
+        with await self.mock_session.pool as connection:
+            pending_length = await connection.llen(self.queue.namespace_pending)
+
+        self.assertEqual(pending_length, 1)
+
+        await task.finalize()
+
+        with await self.mock_session.pool as connection:
+            pending_length = await connection.llen(self.queue.namespace_pending)
+
+        self.assertEqual(pending_length, 0)
+        self.assertTrue(task.done)
+
+    async def test_reschedule_task_puts_task_back_on_queue(self) -> None:
+        """Rescheduling a task should put it back on the queue."""
+        test_value = "Python Discord"
+        await self.queue.put(test_value)
+        self.assertEqual(await self.queue.qsize(), 1)
+
+        task = await self.queue.get()
+        self.assertEqual(await self.queue.qsize(), 0)
+        self.assertEqual(task.value, test_value)
+
+        with await self.mock_session.pool as connection:
+            pending_length = await connection.llen(self.queue.namespace_pending)
+        self.assertEqual(pending_length, 1)
+
+        await self.queue.reschedule_pending_task(task)
+
+        self.assertEqual(await self.queue.qsize(), 1)
+        with await self.mock_session.pool as connection:
+            pending_length = await connection.llen(self.queue.namespace_pending)
+        self.assertEqual(pending_length, 0)
+
+    async def test_reschedule_all_tasks_should_requeue_all_tasks(self) -> None:
+        """Reschedule all tasks should reschedule all tasks in the original order."""
+        task_values = [f"task-{ident}" for ident in range(10)]
+
+        for task_value in task_values:
+            await self.queue.put(task_value)
+
+        self.assertEqual(await self.queue.qsize(), len(task_values))
+
+        task_values_iter = iter(task_values)
+        async for task in self.queue:
+            self.assertEqual(next(task_values_iter), task.value)
+
+        self.assertEqual(await self.queue.qsize(), 0)
+        with await self.mock_session.pool as connection:
+            pending_length = await connection.llen(self.queue.namespace_pending)
+        self.assertEqual(pending_length, 10)
+
+        await self.queue.reschedule_all_pending_client_tasks()
+
+        self.assertEqual(await self.queue.qsize(), 10)
+        with await self.mock_session.pool as connection:
+            pending_length = await connection.llen(self.queue.namespace_pending)
+        self.assertEqual(pending_length, 0)
+
+    async def test_task_raises_TaskAlreadyDone_for_second_finalize(self) -> None:
+        """Should raise TaskAlreadyDone for finalizing a task that is already done."""
+        await self.queue.put("Hello")
+        task = await self.queue.get()
+        await task.finalize()
+
+        with self.assertRaises(types.TaskAlreadyDone):
+            await task.finalize()
+
+    async def test_task_queue_raises_TaskNotPending_for_finalizing_nonpending_task(self) -> None:
+        """Should raise TaskNotPending for finalizing a task not found in pending queue."""
+        await self.queue.put("Hello")
+        task = await self.queue.get()
+        await task.reschedule()
+
+        with self.assertRaises(types.TaskNotPending):
+            await task.finalize()
+
+    async def test_reschedule_task_by_value(self) -> None:
+        """We should also be able to reschedule a task by its value."""
+        value = "Some interesting value"
+        await self.queue.put(value)
+        self.assertEqual((await self.queue.get()).value, value)
+        await self.queue.reschedule_pending_task(value)
+
+        self.assertEqual(await self.queue.qsize(), 1)
+        with await self.mock_session.pool as connection:
+            pending_length = await connection.llen(self.queue.namespace_pending)
+        self.assertEqual(pending_length, 0)
+
+    async def test_rescheduling_unknown_task_raises_TaskNotPending(self) -> None:
+        """Rescheduling an unknown task raises TaskNotPending."""
+        with self.assertRaises(types.TaskNotPending):
+            await self.queue.reschedule_pending_task("non-existent task")
+
+    async def test_task_raises_RuntimeError_for_missing_owner_queue(self):
+        """If the owner queue instance no longer exists, a task should raise a RuntimeError."""
+        await self.queue.put("Hello")
+        task = await self.queue.get()
+        del self.queue
+        with self.assertRaises(RuntimeError):
+            _owner = task.owner
+
+
+class RedisTaskQueueMultipleClientsTests(BaseRedisObjectTests):
+    """Tests for teh RedisTaskQueue class."""
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.queue_one = types.RedisTaskQueue(namespace="task_queue", client_identifier="one")
+        self.queue_two = types.RedisTaskQueue(namespace="task_queue", client_identifier="two")
+
+    async def test_client_pending_queues_are_independent(self) -> None:
+        """The pending queues of different clients should be independent."""
+        values = [f"task-{i}" for i in range(6)]
+
+        for value_one, value_two in zip(*[iter(values)]*2):
+            await self.queue_one.put(value_one)
+            await self.queue_two.put(value_two)
+
+        # The central queue should be the same
+        self.assertEqual(await self.queue_one.qsize(), len(values))
+        self.assertEqual(await self.queue_one.qsize(), await self.queue_two.qsize())
+
+        for value_one, value_two in zip(*[iter(values)]*2):
+            self.assertEqual((await self.queue_one.get()).value, value_one)
+            self.assertEqual((await self.queue_two.get()).value, value_two)
+
+        # The central queue should now be depleted
+        self.assertEqual(await self.queue_one.qsize(), 0)
+        self.assertEqual(await self.queue_one.qsize(), await self.queue_two.qsize())
+
+        with await self.mock_session.pool as connection:
+            pending_one_length = await connection.llen(self.queue_one.namespace_pending)
+            pending_two_length = await connection.llen(self.queue_two.namespace_pending)
+
+        self.assertEqual(pending_one_length, len(values) // 2)
+        self.assertEqual(pending_two_length, len(values) // 2)
+
+        await self.queue_one.reschedule_all_pending_client_tasks()
+
+        with await self.mock_session.pool as connection:
+            pending_one_length = await connection.llen(self.queue_one.namespace_pending)
+            pending_two_length = await connection.llen(self.queue_two.namespace_pending)
+
+        self.assertEqual(pending_one_length, 0)
+        self.assertEqual(pending_two_length, len(values) // 2)
+
+        # Check if the values of queue_one have made it back on the main queue
+        self.assertEqual(await self.queue_one.qsize(), len(values) // 2)
+
+        await self.queue_two.reschedule_all_pending_client_tasks()
+
+        with await self.mock_session.pool as connection:
+            pending_one_length = await connection.llen(self.queue_one.namespace_pending)
+            pending_two_length = await connection.llen(self.queue_two.namespace_pending)
+
+        self.assertEqual(pending_one_length, 0)
+        self.assertEqual(pending_two_length, 0)
+
+        # Check if the values of queue_two have made it back on the main queue
+        self.assertEqual(await self.queue_one.qsize(), len(values))

--- a/tests/types/test_queue.py
+++ b/tests/types/test_queue.py
@@ -229,7 +229,7 @@ class RedisTaskQueueTests(BaseRedisObjectTests):
         task = await self.queue.get()
         del self.queue
         with self.assertRaises(RuntimeError):
-            _owner = task.owner
+            _owner = task.owner  # noqa: F841
 
 
 class RedisTaskQueueMultipleClientsTests(BaseRedisObjectTests):

--- a/tests/types/test_rediscache.py
+++ b/tests/types/test_rediscache.py
@@ -179,3 +179,18 @@ class RedisCacheTests(BaseRedisObjectTests):
                     await self.cache.decrement(target, *increment)
                     post_decrement = await self.cache.get(target)
                     self.assertEqual(local_copy[target], post_decrement)
+
+    async def test_increment_raises_type_error_for_invalid_types(self):
+        """Test if `.increment` raises TypeError for invalid types."""
+        test_cases = (
+            {"initial": 100, "increment": "Python Discord"},
+            {"initial": 1.1, "increment": True},
+            {"initial": "Python Discord", "increment": 200},
+            {"initial": True, "increment": 2.2},
+        )
+
+        for case in test_cases:
+            await self.cache.set("value", case["initial"])
+            with self.subTest(**case):
+                with self.assertRaises(TypeError):
+                    await self.cache.increment("value", amount=case["increment"])


### PR DESCRIPTION
It's high time for a new release of Async RedisCache. This new version will bring a number of new features to this package and add a deprecation warning to the usage of `NamespaceLock`.

## New features
### Atomic Compound Operations
All compound operations consisting of multiple Redis commands should now be atomic from a Redis perspective due to the usage of a Lua Redis script that adds the missing functionality.

### RedisQueue Task Iteration
You can now iterate over a `RedisQueue` with `async for`, optionally using its `iter_tasks` with `wait` to wait for new tasks to become available.

### New type: RedisTaskQueue
A new datatype was added to the package: `RedisTaskQueue`. This queue is similar to a `RedisQeue` except that is uses task tracking: Consumed tasks are temporarily moved to a "pending" queue to make sure data is not lost if a client exits unexpectedly. Once a client is done with processing a task, it can finalize the task to remove it from the "pending" queue.

To support multiple, simultaneous clients, clients can set a "client ID" during initalization to get their own, individual pending queue. In general, clients should reschedule all the tasks in their "pending" queue when they start up to deal with tasks that were never marked as done during their previous run. However, do make sure that a client is able to handle partially processed tasks: If a client exited after processing (some of) the task, but before marking it done, rescheduling the "pending" tasks will make it appear again.

### Set an expiry by duration or timestamp
You can now set an expiry *on an entire namespace* by either an expiration duration or a timestamp (seconds since unix epoch or a datetime.datetime). Please note that setting an expire on a subkey in a RedisCache or an item in a queue is not supported, as Redis only supports setting an expire on the outer key/namespace.

## Deprecated Feature: NamespaceLock
The namespace lock was introduced to deal with non-atomic, compound operations. However, a lock can only guarantee atomicity within one client; it does not actually lock values in the Redis database. That's why I've opted to make the operations themselves atomic from a Redis point of view. This means the NamespaceLock is no longer needed, which also means that there's less of a chance for accidental deadlocks.

I've added a deprecation warning and the lock will be removed in version 1.0.0.

Note: If you're dealing with a single client application and like to make your own methods mutually exclusive/pseudo-atomic, consider using the `RedisObject.atomic_transaction` decorator. It's available on all redis types and all async functions decorated with this decorator will have to acquire the lock (i.e., will run sequentially). 