### PR TITLE
Migrate To redis-py

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ coveralls = "~=2.2.0"
 time-machine = "~=1.3.0"
 
 [packages]
-aioredis = "~=2.0"
+redis = "~=4.2"
 "fakeredis[lua]" = "~=1.7.1"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "730b6225aeef2fb88b6b27fb32ae71e400c4a73a44562affa390d6e2c1f0583c"
+            "sha256": "fadd8d66227389efc6123c67473fdd4667384a3d16f909d33e3e1ab4df891cf1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,14 +16,6 @@
         ]
     },
     "default": {
-        "aioredis": {
-            "hashes": [
-                "sha256:9ac0d0b3b485d293b8ca1987e6de8658d7dafcca1cddfcd1d506cae8cdebfdd6",
-                "sha256:eaa51aaf993f2d71f54b70527c440437ba65340588afeb786cd87c55c89cd98e"
-            ],
-            "index": "pypi",
-            "version": "==2.0.1"
-        },
         "async-timeout": {
             "hashes": [
                 "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15",
@@ -45,12 +37,12 @@
                 "lua"
             ],
             "hashes": [
-                "sha256:7c2c4ba1b42e0a75337c54b777bf0671056b4569650e3ff927e4b9b385afc8ec",
-                "sha256:be3668e50f6b57d5fc4abfd27f9f655bed07a2c5aecfc8b15d0aad59f997c1ba"
+                "sha256:2bc92cece6535961a465991d01841888e0fe2b742ca49aa97ce247b04c9a0ecc",
+                "sha256:e71ca849167052f42f5469a764def9ef35ccffd04773d30b017a7adcc12940c1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.5'",
-            "version": "==1.7.1"
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==1.7.6.1"
         },
         "lupa": {
             "hashes": [
@@ -133,19 +125,19 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
         },
         "redis": {
             "hashes": [
-                "sha256:04629f8e42be942c4f7d1812f2094568f04c612865ad19ad3ace3005da70631a",
-                "sha256:1d9a0cdf89fdd93f84261733e24f55a7bbd413a9b219fdaf56e3e728ca9a2306"
+                "sha256:84316970995a7adb907a56754d2b92d88fc2d252963dc5ac34c88f0f1a22c25d",
+                "sha256:94b617b4cd296e94991146f66fc5559756fbefe9493604f0312e4d3298ac63e9"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.1.4"
+            "index": "pypi",
+            "version": "==4.3.1"
         },
         "six": {
             "hashes": [
@@ -162,83 +154,75 @@
             ],
             "version": "==2.4.0"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
-                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.1.1"
-        },
         "wrapt": {
             "hashes": [
-                "sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b",
-                "sha256:01f799def9b96a8ec1ef6b9c1bbaf2bbc859b87545efbecc4a78faea13d0e3a0",
-                "sha256:09d16ae7a13cff43660155383a2372b4aa09109c7127aa3f24c3cf99b891c330",
-                "sha256:14e7e2c5f5fca67e9a6d5f753d21f138398cad2b1159913ec9e9a67745f09ba3",
-                "sha256:167e4793dc987f77fd476862d32fa404d42b71f6a85d3b38cbce711dba5e6b68",
-                "sha256:1807054aa7b61ad8d8103b3b30c9764de2e9d0c0978e9d3fc337e4e74bf25faa",
-                "sha256:1f83e9c21cd5275991076b2ba1cd35418af3504667affb4745b48937e214bafe",
-                "sha256:21b1106bff6ece8cb203ef45b4f5778d7226c941c83aaaa1e1f0f4f32cc148cd",
-                "sha256:22626dca56fd7f55a0733e604f1027277eb0f4f3d95ff28f15d27ac25a45f71b",
-                "sha256:23f96134a3aa24cc50614920cc087e22f87439053d886e474638c68c8d15dc80",
-                "sha256:2498762814dd7dd2a1d0248eda2afbc3dd9c11537bc8200a4b21789b6df6cd38",
-                "sha256:28c659878f684365d53cf59dc9a1929ea2eecd7ac65da762be8b1ba193f7e84f",
-                "sha256:2eca15d6b947cfff51ed76b2d60fd172c6ecd418ddab1c5126032d27f74bc350",
-                "sha256:354d9fc6b1e44750e2a67b4b108841f5f5ea08853453ecbf44c81fdc2e0d50bd",
-                "sha256:36a76a7527df8583112b24adc01748cd51a2d14e905b337a6fefa8b96fc708fb",
-                "sha256:3a0a4ca02752ced5f37498827e49c414d694ad7cf451ee850e3ff160f2bee9d3",
-                "sha256:3a71dbd792cc7a3d772ef8cd08d3048593f13d6f40a11f3427c000cf0a5b36a0",
-                "sha256:3a88254881e8a8c4784ecc9cb2249ff757fd94b911d5df9a5984961b96113fff",
-                "sha256:47045ed35481e857918ae78b54891fac0c1d197f22c95778e66302668309336c",
-                "sha256:4775a574e9d84e0212f5b18886cace049a42e13e12009bb0491562a48bb2b758",
-                "sha256:493da1f8b1bb8a623c16552fb4a1e164c0200447eb83d3f68b44315ead3f9036",
-                "sha256:4b847029e2d5e11fd536c9ac3136ddc3f54bc9488a75ef7d040a3900406a91eb",
-                "sha256:59d7d92cee84a547d91267f0fea381c363121d70fe90b12cd88241bd9b0e1763",
-                "sha256:5a0898a640559dec00f3614ffb11d97a2666ee9a2a6bad1259c9facd01a1d4d9",
-                "sha256:5a9a1889cc01ed2ed5f34574c90745fab1dd06ec2eee663e8ebeefe363e8efd7",
-                "sha256:5b835b86bd5a1bdbe257d610eecab07bf685b1af2a7563093e0e69180c1d4af1",
-                "sha256:5f24ca7953f2643d59a9c87d6e272d8adddd4a53bb62b9208f36db408d7aafc7",
-                "sha256:61e1a064906ccba038aa3c4a5a82f6199749efbbb3cef0804ae5c37f550eded0",
-                "sha256:65bf3eb34721bf18b5a021a1ad7aa05947a1767d1aa272b725728014475ea7d5",
-                "sha256:6807bcee549a8cb2f38f73f469703a1d8d5d990815c3004f21ddb68a567385ce",
-                "sha256:68aeefac31c1f73949662ba8affaf9950b9938b712fb9d428fa2a07e40ee57f8",
-                "sha256:6915682f9a9bc4cf2908e83caf5895a685da1fbd20b6d485dafb8e218a338279",
-                "sha256:6d9810d4f697d58fd66039ab959e6d37e63ab377008ef1d63904df25956c7db0",
-                "sha256:729d5e96566f44fccac6c4447ec2332636b4fe273f03da128fff8d5559782b06",
-                "sha256:748df39ed634851350efa87690c2237a678ed794fe9ede3f0d79f071ee042561",
-                "sha256:763a73ab377390e2af26042f685a26787c402390f682443727b847e9496e4a2a",
-                "sha256:8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311",
-                "sha256:8529b07b49b2d89d6917cfa157d3ea1dfb4d319d51e23030664a827fe5fd2131",
-                "sha256:87fa943e8bbe40c8c1ba4086971a6fefbf75e9991217c55ed1bcb2f1985bd3d4",
-                "sha256:88236b90dda77f0394f878324cfbae05ae6fde8a84d548cfe73a75278d760291",
-                "sha256:891c353e95bb11abb548ca95c8b98050f3620a7378332eb90d6acdef35b401d4",
-                "sha256:89ba3d548ee1e6291a20f3c7380c92f71e358ce8b9e48161401e087e0bc740f8",
-                "sha256:8c6be72eac3c14baa473620e04f74186c5d8f45d80f8f2b4eda6e1d18af808e8",
-                "sha256:9a242871b3d8eecc56d350e5e03ea1854de47b17f040446da0e47dc3e0b9ad4d",
-                "sha256:9a3ff5fb015f6feb78340143584d9f8a0b91b6293d6b5cf4295b3e95d179b88c",
-                "sha256:9a5a544861b21e0e7575b6023adebe7a8c6321127bb1d238eb40d99803a0e8bd",
-                "sha256:9d57677238a0c5411c76097b8b93bdebb02eb845814c90f0b01727527a179e4d",
-                "sha256:9d8c68c4145041b4eeae96239802cfdfd9ef927754a5be3f50505f09f309d8c6",
-                "sha256:9d9fcd06c952efa4b6b95f3d788a819b7f33d11bea377be6b8980c95e7d10775",
-                "sha256:a0057b5435a65b933cbf5d859cd4956624df37b8bf0917c71756e4b3d9958b9e",
-                "sha256:a65bffd24409454b889af33b6c49d0d9bcd1a219b972fba975ac935f17bdf627",
-                "sha256:b0ed6ad6c9640671689c2dbe6244680fe8b897c08fd1fab2228429b66c518e5e",
-                "sha256:b21650fa6907e523869e0396c5bd591cc326e5c1dd594dcdccac089561cacfb8",
-                "sha256:b3f7e671fb19734c872566e57ce7fc235fa953d7c181bb4ef138e17d607dc8a1",
-                "sha256:b77159d9862374da213f741af0c361720200ab7ad21b9f12556e0eb95912cd48",
-                "sha256:bb36fbb48b22985d13a6b496ea5fb9bb2a076fea943831643836c9f6febbcfdc",
-                "sha256:d066ffc5ed0be00cd0352c95800a519cf9e4b5dd34a028d301bdc7177c72daf3",
-                "sha256:d332eecf307fca852d02b63f35a7872de32d5ba8b4ec32da82f45df986b39ff6",
-                "sha256:d808a5a5411982a09fef6b49aac62986274ab050e9d3e9817ad65b2791ed1425",
-                "sha256:d9bdfa74d369256e4218000a629978590fd7cb6cf6893251dad13d051090436d",
-                "sha256:db6a0ddc1282ceb9032e41853e659c9b638789be38e5b8ad7498caac00231c23",
-                "sha256:debaf04f813ada978d7d16c7dfa16f3c9c2ec9adf4656efdc4defdf841fc2f0c",
-                "sha256:f0408e2dbad9e82b4c960274214af533f856a199c9274bd4aff55d4634dedc33",
-                "sha256:f2f3bc7cd9c9fcd39143f11342eb5963317bd54ecc98e3650ca22704b69d9653"
+                "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3",
+                "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
+                "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
+                "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+                "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
+                "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3",
+                "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
+                "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
+                "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
+                "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
+                "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
+                "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+                "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+                "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87",
+                "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+                "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+                "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907",
+                "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
+                "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
+                "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28",
+                "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
+                "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853",
+                "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
+                "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
+                "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3",
+                "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164",
+                "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
+                "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c",
+                "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
+                "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
+                "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1",
+                "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+                "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed",
+                "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1",
+                "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
+                "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
+                "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
+                "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
+                "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef",
+                "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
+                "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+                "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+                "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
+                "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
+                "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d",
+                "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8",
+                "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5",
+                "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471",
+                "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00",
+                "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
+                "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+                "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d",
+                "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
+                "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
+                "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
+                "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7",
+                "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59",
+                "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5",
+                "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+                "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b",
+                "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
+                "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462",
+                "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
+                "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.14.0"
+            "version": "==1.14.1"
         }
     },
     "develop": {
@@ -252,18 +236,19 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
             ],
-            "version": "==2021.10.8"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.6.15"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==2.0.12"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.0"
         },
         "coverage": {
             "extras": [
@@ -416,7 +401,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_version >= '3'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.3"
         },
         "mccabe": {
@@ -468,11 +453,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
-                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.27.1"
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==2.28.1"
         },
         "six": {
             "hashes": [
@@ -521,11 +506,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
-                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
+                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.9"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.10"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use a `RedisCache`, you first have to create a `RedisSession` instance that m
 import async_rediscache
 
 async def main():
-    session = async_rediscache.RedisSession("redis://localhost")
+    session = async_rediscache.RedisSession(host="localhost")
     await session.connect()
 
     # Do something interesting
@@ -83,7 +83,7 @@ Here are some usage examples:
 import async_rediscache
 
 async def main():
-    session = async_rediscache.RedisSession("redis://localhost")
+    session = async_rediscache.RedisSession(host="localhost")
     await session.connect()
 
     cache = async_rediscache.RedisCache(namespace="python")

--- a/async_rediscache/session.py
+++ b/async_rediscache/session.py
@@ -127,6 +127,8 @@ class RedisSession(metaclass=RedisSingleton):
         Connect to Redis by instantiating the redis instance.
 
         If ping is True, a PING will be performed to ensure the connection is valid.
+        If it's False, it'll be assumed the session is valid, and it's up to the user to
+        manage when it's not.
         """
         log.debug("Creating Redis client.")
 
@@ -158,6 +160,6 @@ class RedisSession(metaclass=RedisSingleton):
         if ping:
             # Perform a PING to confirm the connection is valid
             await self._client.ping()
-            self.valid = True
 
+        self.valid = True
         return self

--- a/async_rediscache/session.py
+++ b/async_rediscache/session.py
@@ -15,7 +15,7 @@ class RedisSessionNotInitialized(RuntimeError):
 
 
 class RedisSessionNotConnected(RuntimeError):
-    """Raised when trying to access the Redis client before connect has been called."""
+    """Raised when trying to access the Redis client before `connect` has been called."""
 
 
 class FakeRedisNotInstalled(ImportError):

--- a/async_rediscache/session.py
+++ b/async_rediscache/session.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
+import warnings
 
-import aioredis
+import redis.asyncio
 
 __all__ = ['RedisSession', 'RedisSessionNotInitialized', 'RedisSessionNotConnected']
 
@@ -14,7 +15,7 @@ class RedisSessionNotInitialized(RuntimeError):
 
 
 class RedisSessionNotConnected(RuntimeError):
-    """Raised when trying to access the Redis client before a connection has been created."""
+    """Raised when trying to access the Redis client before connect has been called."""
 
 
 class FakeRedisNotInstalled(ImportError):
@@ -47,18 +48,16 @@ class RedisSession(metaclass=RedisSingleton):
     A RedisSession that manages the lifetime of a Redis client instance.
 
     To avoid making the client access more complicated than it needs to be for
-    a client that should only be created once during the bot's runtime, the
+    a client that should only be created once during the application's runtime, the
     `RedisSession` instance should be created and its `connect` method should be
     awaited before the tasks get scheduled that rely on the Redis client.
 
-    The easiest way to do that is to get the event loop before `discord.py`
-    creates it, run the loop until the `connect` coroutine is completed, and
-    passing the loop to `discord.ext.commands.Bot.__init__` afterwards.
-
-    The `url` argument, and kwargs are passed directly to the `aioredis.from_url` method.
+    If using a third party library which interacts with the event loop, obtain it before it's
+    created, and run the loop until the `connect` coroutine is completed.
+    Pass the loop to library.
 
     Example:
-        redis_session = RedisSession("redis://localhost")
+        redis_session = RedisSession(host="localhost", port=6379)
         loop = asyncio.get_event_loop()
         loop.run_until_complete(redis_session.connect())
         bot = discord.ext.commands.Bot(..., loop=loop)
@@ -67,19 +66,19 @@ class RedisSession(metaclass=RedisSingleton):
     _instance: RedisSession = None
 
     def __init__(
-        self, url: str, *, global_namespace: str = "", use_fakeredis: bool = False, **session_kwargs
+        self, *, global_namespace: str = "", use_fakeredis: bool = False, **session_kwargs
     ) -> None:
         self.global_namespace = global_namespace
-        self.url = url
+
         self._client = None
         self._session_kwargs = session_kwargs
         self._use_fakeredis = use_fakeredis
-        self.connected = False
+        self.valid = False
 
     @classmethod
     def get_current_session(cls) -> RedisSession:
         """
-        Get the currently connected RedisSession instance.
+        Get the currently configured RedisSession instance.
 
         If an instance has not been created yet as this point, this method will
         raise a `RedisSessionNotInitialized` exception.
@@ -90,21 +89,45 @@ class RedisSession(metaclass=RedisSingleton):
         return cls._instance
 
     @property
-    def client(self) -> aioredis.Redis:
+    def client(self) -> redis.asyncio.Redis:
         """
-        Get the redis client object to perform commands on.
+        Get the redis client after that it was initialized.
 
         This property will raise a `RedisSessionNotConnected` if it is accessed
         before the connect method is called.
         """
-        if not self.connected:
+        if not self.valid:
             raise RedisSessionNotConnected(
                 "attempting to access the client before the connection has been created."
             )
         return self._client
 
-    async def connect(self) -> None:
-        """Connect to Redis by instantiating the redis instance."""
+    @property
+    def pool(self) -> redis.asyncio.ConnectionPool:
+        """
+        Get the connection pool after checking if it is still connected.
+
+        This property is deprecated. Most operations should be performed on
+        the client directly. Operations which benefit from managing the pool directly
+        can access it from `client.connection_pool`.
+
+        This property will raise a `RedisSessionNotConnected` if it's accessed after
+        before the connect method is called.
+        """
+        # The validation and error logic is handled by the client property
+        warnings.warn(DeprecationWarning(
+            "pool property is deprecated. Most operations should be performed on "
+            "the client directly. Operations which benefit from managing the pool directly "
+            "can access it from client.connection_pool."
+        ))
+        return self.client.connection_pool
+
+    async def connect(self, *, ping: bool = True) -> RedisSession:
+        """
+        Connect to Redis by instantiating the redis instance.
+
+        If ping is True, a PING will be performed to ensure the connection is valid.
+        """
         log.debug("Creating Redis client.")
 
         # Decide if we want to use `fakeredis` or an actual Redis server. The
@@ -116,7 +139,7 @@ class RedisSession(metaclass=RedisSingleton):
             # required dependency if someone's not planning on using it.
             try:
                 import fakeredis.aioredis
-            except ImportError:
+            except ImportError:  # pragma: no cover
                 raise FakeRedisNotInstalled(
                     "RedisSession was configured to use `fakeredis`, but it is not installed. "
                     "Either install `fakeredis` manually or install `async-rediscache` using "
@@ -124,20 +147,17 @@ class RedisSession(metaclass=RedisSingleton):
                 )
 
             kwargs = dict(self._session_kwargs)
-            # Match the behavior of `aioredis.from_url` by updating the kwargs using the URL
-            url_options = aioredis.connection.parse_url(self.url)
-            kwargs.update(dict(url_options))
-
             # The following kwargs are not supported by fakeredis
             [kwargs.pop(kwarg, None) for kwarg in (
                 "address", "username", "password", "port", "timeout"
             )]
-
             self._client = fakeredis.aioredis.FakeRedis(**kwargs)
         else:
-            self._client = aioredis.from_url(self.url, **self._session_kwargs)
+            self._client = redis.asyncio.Redis(**self._session_kwargs)
 
-        # The connection pool client does not expose any way to connect to the server, so
-        # we try to perform a request to confirm the connection
-        await self._client.ping()
-        self.connected = True
+        if ping:
+            # Perform a PING to confirm the connection is valid
+            await self._client.ping()
+            self.valid = True
+
+        return self

--- a/async_rediscache/types/cache.py
+++ b/async_rediscache/types/cache.py
@@ -86,11 +86,12 @@ class RedisCache(RedisObject):
         value = await self.redis_session.client.hget(self.namespace, key)
         return self._maybe_value_from_typestring(value, default)
 
-    async def delete(self, key: RedisKeyType) -> None:
+    async def delete(self, key: RedisKeyType) -> int:
         """
         Delete an item from the Redis cache.
 
         If we try to delete a key that does not exist, it will simply be ignored.
+        Returns the number of deleted keys.
 
         See https://redis.io/commands/hdel for more info on how this works.
         """

--- a/async_rediscache/types/queue.py
+++ b/async_rediscache/types/queue.py
@@ -6,7 +6,7 @@ import typing
 import weakref
 from typing import Optional
 
-import aioredis
+import redis
 
 from .base import RedisObject, RedisValueType
 
@@ -192,7 +192,7 @@ class RedisTaskQueue(RedisQueue):
 
         task.done = True
 
-    async def reschedule_pending_task(self, task: typing.Union[RedisValueType. RedisTask]) -> None:
+    async def reschedule_pending_task(self, task: typing.Union[RedisValueType, RedisTask]) -> None:
         """
         Move a `task` from the pending tasks queue back to the main queue.
 
@@ -212,7 +212,7 @@ class RedisTaskQueue(RedisQueue):
             keys = [self.namespace, self.namespace_pending]
             args = [self._value_to_typestring(task)]
             await self.redis_session.client.evalsha(reschedule_script, len(keys), *keys, *args)
-        except aioredis.ResponseError:
+        except redis.ResponseError:
             raise TaskNotPending(
                 f"task `{task}` not found in pending tasks queue `{self.namespace_pending}`"
             ) from None

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="async-rediscache",
-    version="1.0.0rc1",
+    version="1.0.0rc2",
     description="An easy to use asynchronous Redis cache",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -32,7 +32,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=[
-        "aioredis~=2.0"
+        "redis~=4.2"
     ],
     python_requires='~=3.7',
     extras_require={

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,19 +6,14 @@ from async_rediscache import session
 class RedisSessionTests(unittest.IsolatedAsyncioTestCase):
     """Tests for the RedisSession wrapper class."""
 
-    def tearDown(self) -> None:
+    def setUp(self) -> None:
         """Explicitly remove `RedisSession`s after each test."""
-        try:
-            redis_session = session.RedisSession.get_current_session()
-            redis_session.client.flushall()
-        except (session.RedisSessionNotInitialized, session.RedisSessionNotConnected):
-            pass
         session.RedisSession._instance = None
 
     async def test_singleton(self):
         """Test that the same session is returned from multiple constructions."""
-        first = session.RedisSession("", use_fakeredis=True)
-        second = session.RedisSession("", use_fakeredis=True)
+        first = session.RedisSession(use_fakeredis=True)
+        second = session.RedisSession(use_fakeredis=True)
         self.assertIs(first, second, "Only one RedisSession should exist at runtime.")
         self.assertIs(
             first,
@@ -34,14 +29,17 @@ class RedisSessionTests(unittest.IsolatedAsyncioTestCase):
     async def test_error_if_not_connected(self):
         """Test that no operations can be performed until the connect method is called."""
         with self.assertRaises(session.RedisSessionNotConnected):
-            _ = session.RedisSession("").client
+            _ = session.RedisSession().client
 
-    async def test_fakeredis_get_args_from_url(self):
-        """Test that sessions using fakeredis correctly parse arguments from the url."""
-        # Using a URI with all arguments to ensure everything works as expected
-        redis_session = session.RedisSession(
-            "redis://username:password@localhost:6379/1?timeout=32s",
-            use_fakeredis=True
-        )
-        await redis_session.connect()
-        self.assertEqual(1, redis_session.client.connection_pool.connection_kwargs["db"])
+    async def test_pool_deprecation_warning(self):
+        """Test that accessing the pool through the session outputs a warning."""
+        redis_session = await session.RedisSession(use_fakeredis=True).connect()
+        with self.assertWarns(DeprecationWarning):
+            _ = redis_session.pool
+
+    @staticmethod
+    async def test_no_connect_operations():
+        """Test that no operations are performed on connect if ping is False."""
+        # We use a purposefully invalid real connection, which should fail
+        # should any operations be attempted.
+        await session.RedisSession(host="invalid").connect(ping=False)


### PR DESCRIPTION
Closes #19 

Since aioredis v2 (#18) is a subset of redis-py, this was a drop in replacement. I did however spend some time touching up the session interface and bringing it back to more what it was like before aioredis 2. There was also a small typing change which I lumped into here. It's minor enough that we probably shouldn't worry about backporting.

Note that we still technically use a little of the aioredis interface when fakeredis is true, because the redis native-async support does not seem to exist within fakeredis yet. This is not an issue however since the fakeredis interface is actually much closer to redis-py than aioredis. 

Changelog for release candidate

## Added
- `RedisSession.connect` can take an optional `ping` flag which specifies if the services should be validated with a PING

## Changed
- Switch aioredis for `redis ~= 4.2.0`
- `RedisSession` no longer takes a URL, but accepts all parameters which can be passed to `redis.asyncio.Redis`
- `RedisSessionNotConnected` is more explicit about the issue being a lack of calling the `connect` method, as opposed to actually being connected.
- `RedisSession.connected` has been renamed to `RedisSession.valid`

## Deprecated
- `RedisSession.pool` has been deprecated due to being an unnecessary wrapper around `RedisSession.client.connection_pool`. For most cases, you should perform the operations directly from the client, and it'll manage all the pooling overhead. If you truly need to access the pool directly, you can do so through the client.
